### PR TITLE
Use Honk font for desktop icon labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <title>Samuel Witt — Portfolio</title>
 <meta name="description" content="Interactive Win95-style desktop portfolio."/>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Monaco&display=swap">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Honk&display=swap">
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -48,7 +48,7 @@ body{margin:0; font:14px/1 "Jersey 20", sans-serif; color:var(--text); backgroun
 }
 .icon .label {
   color:#fff;            /* 👈 white text (hard to see on yellow) */
-  font-family:"Atomic Age", cursive;
+  font-family:"Honk", "Atomic Age", "Segoe UI", sans-serif;
   font-size:22px;
   text-shadow:1px 1px 0 #000;
   text-align:center;


### PR DESCRIPTION
## Summary
- load the Honk Google Font so it is available to the site
- switch desktop icon labels to the Honk font with appropriate fallbacks

## Testing
- python -m http.server 8000 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68e079f401dc832293a85190ba250889