### PR TITLE
Increase desktop icon label size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -49,7 +49,7 @@ body{margin:0; font:14px/1 "Jersey 20", sans-serif; color:var(--text); backgroun
 .icon .label {
   color:#fff;            /* 👈 white text (hard to see on yellow) */
   font-family:"Honk", "Atomic Age", "Segoe UI", sans-serif;
-  font-size:22px;
+  font-size:32px;
   text-shadow:1px 1px 0 #000;
   text-align:center;
 }


### PR DESCRIPTION
## Summary
- enlarge the desktop icon label font size for improved visibility

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e084fcab3c8322ab9ba6721b0fe8b0