### PR TITLE
Add solitaire desktop game window

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,9 +32,9 @@
   <img src="assets/img/Contact1.png" alt="" />
   <div class="label">Contact</div>
 </div>
-<div class="icon sticky" tabindex="0" role="button" aria-label="Sticky Notes">
-  <img src="assets/img/Stickynotes.png" alt="" /> 
-  <div class="label">Sticky Notes </div> 
+<div class="icon solitaire" tabindex="0" role="button" aria-label="Solitaire">
+  <img src="assets/img/Stickynotes.png" alt="" />
+  <div class="label">Solitaire</div>
 </div>
 <div class="icon publishers" tabindex="0" role="button" aria-label="Publishers">
   <img src="assets/img/vinyl.png" alt="" />
@@ -71,8 +71,8 @@
     <span>Publishers</span>
   </div>
   <div class="hr" role="separator"></div>
-  <div class="item" role="menuitem" data-sticky="new">
-    <span>New Sticky Note</span>
+  <div class="item" role="menuitem" data-open="solitaire">
+    <span>Play Solitaire</span>
   </div>
   <div class="item" role="menuitem" data-cmd="closeAll">
     <span>Close All Windows</span>
@@ -527,6 +527,43 @@
   </section>
 </template>
 
+<template id="tpl-solitaire">
+  <section class="content-section solitaire" aria-labelledby="solitaire-heading">
+    <header class="solitaire-toolbar">
+      <div class="solitaire-heading">
+        <h2 id="solitaire-heading">Solitaire</h2>
+        <p class="solitaire-instructions">Draw cards from the stock, build descending stacks on the tableau, and send cards to the foundations in ascending order.</p>
+      </div>
+      <div class="solitaire-actions" role="group" aria-label="Solitaire controls">
+        <button type="button" class="solitaire-btn restart">Restart</button>
+        <button type="button" class="solitaire-btn undo" disabled>Undo</button>
+      </div>
+    </header>
+    <div class="solitaire-status" role="status" aria-live="polite">Good luck!</div>
+    <div class="solitaire-board" role="group" aria-label="Solitaire board">
+      <div class="solitaire-row solitaire-row--top">
+        <div class="pile pile-stock" data-pile="stock" tabindex="0" role="button" aria-label="Stock pile. Press Enter or Space to draw a card."></div>
+        <div class="pile pile-waste" data-pile="waste" tabindex="0" role="group" aria-label="Waste pile"></div>
+        <div class="solitaire-foundations" role="group" aria-label="Foundation piles">
+          <div class="pile pile-foundation" data-pile="foundation-0" tabindex="0" role="group" aria-label="Foundation pile one"></div>
+          <div class="pile pile-foundation" data-pile="foundation-1" tabindex="0" role="group" aria-label="Foundation pile two"></div>
+          <div class="pile pile-foundation" data-pile="foundation-2" tabindex="0" role="group" aria-label="Foundation pile three"></div>
+          <div class="pile pile-foundation" data-pile="foundation-3" tabindex="0" role="group" aria-label="Foundation pile four"></div>
+        </div>
+      </div>
+      <div class="solitaire-row solitaire-row--tableau" role="group" aria-label="Tableau piles">
+        <div class="pile pile-tableau" data-pile="tableau-0" tabindex="0" aria-label="Tableau pile one"></div>
+        <div class="pile pile-tableau" data-pile="tableau-1" tabindex="0" aria-label="Tableau pile two"></div>
+        <div class="pile pile-tableau" data-pile="tableau-2" tabindex="0" aria-label="Tableau pile three"></div>
+        <div class="pile pile-tableau" data-pile="tableau-3" tabindex="0" aria-label="Tableau pile four"></div>
+        <div class="pile pile-tableau" data-pile="tableau-4" tabindex="0" aria-label="Tableau pile five"></div>
+        <div class="pile pile-tableau" data-pile="tableau-5" tabindex="0" aria-label="Tableau pile six"></div>
+        <div class="pile pile-tableau" data-pile="tableau-6" tabindex="0" aria-label="Tableau pile seven"></div>
+      </div>
+    </div>
+  </section>
+</template>
+
 <template id="tpl-contact">
   <section class="content-section contact" aria-labelledby="contact-heading">
     <h2 id="contact-heading">Let&apos;s Collaborate</h2>
@@ -545,5 +582,6 @@
 
 
 <script src="script.js" defer></script>
+<script src="solitaire.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -442,29 +442,14 @@ const openers = {
     const win = makeWindow({ title: 'Publishers', tpl: 'tpl-publishers', x: 220, y: 200, w: 440 });
     if (typeof initPublishersWindow === 'function') initPublishersWindow(win);
     return win;
+  },
+
+  solitaire: () => {
+    const win = makeWindow({ title: 'Solitaire', tpl: 'tpl-solitaire', x: 280, y: 140, w: 780 });
+    if (typeof initSolitaireWindow === 'function') initSolitaireWindow(win);
+    return win;
   }
 };
-
-
-
-// Sticky Notes
-function createNote({x=260,y=100,w=220,h=160,text='New note…'}={}){
-  const note = document.createElement('div');
-  note.className='sticky-note';
-  note.style.left=x+'px'; note.style.top=y+'px'; note.style.width=w+'px'; note.style.height=h+'px';
-  note.innerHTML = '<div class="close" title="Delete">✕</div><div class="body" contenteditable="true">'+text+'</div>';
-  desktop.appendChild(note);
-  // drag (not when typing)
-  let drag=false, ox=0, oy=0;
-  note.addEventListener('mousedown', e=>{ if(e.target.closest('.body')||e.target.closest('.close')) return; drag=true; ox=e.clientX-note.offsetLeft; oy=e.clientY-note.offsetTop; e.preventDefault();
-    const mv=(e)=>{ if(!drag) return; note.style.left=e.clientX-ox+'px'; note.style.top=e.clientY-oy+'px'; };
-    const up=()=>{ drag=false; window.removeEventListener('mousemove', mv); window.removeEventListener('mouseup', up); };
-    window.addEventListener('mousemove', mv); window.addEventListener('mouseup', up);
-  });
-  note.querySelector('.close').addEventListener('click', ()=> note.remove());
-  return note;
-}
-
 // Icon drag + dblclick handlers
 document.querySelectorAll('.icon').forEach(icon => {
   let dragging=false, moved=false, offsetX=0, offsetY=0;
@@ -546,13 +531,11 @@ document.querySelectorAll('.icon').forEach(icon => {
   });
   icon.addEventListener('dblclick', e=>{
     if(moved) return;
-    if(icon.classList.contains('sticky')){ createNote(); return; }
     const name = [...icon.classList].find(c=> openers[c]);
     if(name) openers[name]();
   });
   icon.addEventListener('keydown', e=>{
     if(e.key==='Enter'){
-      if(icon.classList.contains('sticky')){ createNote(); return; }
       const name = [...icon.classList].find(c=> openers[c]);
       if(name) openers[name]();
     }
@@ -611,7 +594,7 @@ tick(); setInterval(tick, 1000);
   desktop.addEventListener('pointerdown', (e)=>{
     if(e.pointerType==='mouse' && e.button!==0) return;
     if(pointerId!==null) return;
-    if(e.target.closest('.icon, .window, .sticky-note, .taskbar, #startMenu')) return;
+    if(e.target.closest('.icon, .window, .taskbar, #startMenu')) return;
     pointerId=e.pointerId;
     startX=e.clientX; startY=e.clientY;
     shiftPressed=e.shiftKey;
@@ -662,7 +645,6 @@ startMenu.addEventListener('click', (e)=>{
   const item = e.target.closest('.item'); if(!item) return;
   const op = item.getAttribute('data-open');
   if(op && openers[op]){ openers[op](); toggleStart(false); return; }
-  if(item.getAttribute('data-sticky')==='new'){ createNote(); toggleStart(false); return; }
   if(item.getAttribute('data-cmd')==='closeAll'){
     document.querySelectorAll('.window').forEach(w=>w.remove());
     document.querySelectorAll('.task-btn').forEach(b=>b.remove());

--- a/solitaire.js
+++ b/solitaire.js
@@ -1,0 +1,734 @@
+(function(){
+  const SUIT_NAMES = ['spades', 'hearts', 'diamonds', 'clubs'];
+  const SUIT_SYMBOLS = { spades: '♠', hearts: '♥', diamonds: '♦', clubs: '♣' };
+  const SUIT_READABLE = { spades: 'Spades', hearts: 'Hearts', diamonds: 'Diamonds', clubs: 'Clubs' };
+  const SUIT_COLORS = { spades: 'black', clubs: 'black', hearts: 'red', diamonds: 'red' };
+  const RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+  const CARD_HEIGHT = 120;
+  const FACE_DOWN_SPACING = 22;
+  const FACE_UP_SPACING = 32;
+  const WASTE_SPACING = 18;
+
+  function createDeck(){
+    const deck = [];
+    for(let s = 0; s < SUIT_NAMES.length; s++){
+      const suitName = SUIT_NAMES[s];
+      for(let r = 0; r < RANKS.length; r++){
+        deck.push({
+          id: `${suitName}-${RANKS[r]}`,
+          suit: suitName,
+          rank: RANKS[r],
+          value: r + 1,
+          color: SUIT_COLORS[suitName],
+          faceUp: false
+        });
+      }
+    }
+    return deck;
+  }
+
+  function shuffle(array){
+    for(let i = array.length - 1; i > 0; i--){
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+  }
+
+  function cloneCard(card){
+    return { ...card };
+  }
+
+  function clonePile(pile){
+    return pile.map(cloneCard);
+  }
+
+  function describeCard(card){
+    if(!card) return '';
+    return `${card.rank} of ${SUIT_READABLE[card.suit]}`;
+  }
+
+  function pluralize(count, singular, plural){
+    if(plural === undefined) plural = `${singular}s`;
+    return `${count} ${count === 1 ? singular : plural}`;
+  }
+
+  function initSolitaireWindow(win){
+    if(!win) return;
+    const board = win.querySelector('.solitaire-board');
+    if(!board) return;
+
+    const statusEl = win.querySelector('.solitaire-status');
+    const restartBtn = win.querySelector('.solitaire-btn.restart');
+    const undoBtn = win.querySelector('.solitaire-btn.undo');
+    const stockEl = board.querySelector('[data-pile="stock"]');
+    const wasteEl = board.querySelector('[data-pile="waste"]');
+    const foundationEls = Array.from(board.querySelectorAll('.pile-foundation'));
+    const tableauEls = Array.from(board.querySelectorAll('.pile-tableau'));
+
+    const state = {
+      stock: [],
+      waste: [],
+      foundations: Array.from({ length: 4 }, () => []),
+      tableau: Array.from({ length: 7 }, () => []),
+      history: []
+    };
+
+    let focusToken = null;
+    let pendingFocusToken = null;
+    let dragState = null;
+    let dropTarget = null;
+
+    function updateStatus(message){
+      if(statusEl) statusEl.textContent = message;
+    }
+
+    function updateUndo(){
+      if(undoBtn) undoBtn.disabled = state.history.length === 0;
+    }
+
+    function saveState(){
+      state.history.push({
+        stock: clonePile(state.stock),
+        waste: clonePile(state.waste),
+        foundations: state.foundations.map(clonePile),
+        tableau: state.tableau.map(clonePile),
+        status: statusEl ? statusEl.textContent : ''
+      });
+      updateUndo();
+    }
+
+    function restoreSnapshot(snapshot){
+      state.stock = clonePile(snapshot.stock);
+      state.waste = clonePile(snapshot.waste);
+      state.foundations = snapshot.foundations.map(clonePile);
+      state.tableau = snapshot.tableau.map(clonePile);
+    }
+
+    function getCardLocation(cardId){
+      for(let i = 0; i < state.tableau.length; i++){
+        const idx = state.tableau[i].findIndex(card => card.id === cardId);
+        if(idx !== -1){
+          return { type: 'tableau', index: i, position: idx, card: state.tableau[i][idx], pile: state.tableau[i] };
+        }
+      }
+      const wasteIndex = state.waste.findIndex(card => card.id === cardId);
+      if(wasteIndex !== -1){
+        return { type: 'waste', index: wasteIndex, position: wasteIndex, card: state.waste[wasteIndex], pile: state.waste };
+      }
+      for(let i = 0; i < state.foundations.length; i++){
+        const idx = state.foundations[i].findIndex(card => card.id === cardId);
+        if(idx !== -1){
+          return { type: 'foundation', index: i, position: idx, card: state.foundations[i][idx], pile: state.foundations[i] };
+        }
+      }
+      return null;
+    }
+
+    function flipTableauTop(index){
+      const pile = state.tableau[index];
+      if(!pile || !pile.length) return;
+      const top = pile[pile.length - 1];
+      if(top && !top.faceUp){
+        top.faceUp = true;
+      }
+    }
+
+    function removeFromOrigin(origin, count){
+      if(!origin) return [];
+      if(origin.type === 'tableau'){
+        const pile = state.tableau[origin.index];
+        const removed = pile.splice(origin.position, count);
+        flipTableauTop(origin.index);
+        return removed;
+      }
+      if(origin.type === 'waste'){
+        return state.waste.splice(state.waste.length - count, count);
+      }
+      if(origin.type === 'foundation'){
+        return state.foundations[origin.index].splice(origin.position, count);
+      }
+      return [];
+    }
+
+    function addToTarget(target, cards){
+      if(!cards.length) return;
+      if(target.type === 'tableau'){
+        state.tableau[target.index].push(...cards);
+      } else if(target.type === 'foundation'){
+        state.foundations[target.index].push(...cards);
+      }
+    }
+
+    function isValidTableauMove(cards, targetIndex){
+      if(!cards.length) return false;
+      const pile = state.tableau[targetIndex];
+      const first = cards[0];
+      if(!first.faceUp) return false;
+      if(!pile.length){
+        return first.value === 13; // King on empty pile
+      }
+      const top = pile[pile.length - 1];
+      if(!top.faceUp) return false;
+      return top.color !== first.color && top.value === first.value + 1;
+    }
+
+    function isValidFoundationMove(card, targetIndex){
+      if(!card || !card.faceUp) return false;
+      const pile = state.foundations[targetIndex];
+      if(!pile.length) return card.value === 1; // Ace
+      const top = pile[pile.length - 1];
+      return top.suit === card.suit && top.value + 1 === card.value;
+    }
+
+    function describeTargetFromElement(element){
+      if(!element) return null;
+      const pileName = element.getAttribute('data-pile');
+      if(!pileName) return null;
+      if(pileName.startsWith('tableau-')){
+        return { type: 'tableau', index: Number(pileName.split('-')[1]) };
+      }
+      if(pileName.startsWith('foundation-')){
+        return { type: 'foundation', index: Number(pileName.split('-')[1]) };
+      }
+      return null;
+    }
+
+    function isSameDestination(a, b){
+      if(!a || !b) return false;
+      if(a.type !== b.type) return false;
+      if('index' in a || 'index' in b){
+        return a.index === b.index;
+      }
+      return true;
+    }
+
+    function isDropAllowed(descriptor, drag){
+      if(!descriptor || !drag) return false;
+      if(descriptor.type === 'tableau'){
+        if(drag.origin.type === 'tableau' && drag.origin.index === descriptor.index) return false;
+        return isValidTableauMove(drag.stack, descriptor.index);
+      }
+      if(descriptor.type === 'foundation'){
+        if(drag.stack.length !== 1) return false;
+        return isValidFoundationMove(drag.stack[0], descriptor.index);
+      }
+      return false;
+    }
+
+    function setDropTarget(element){
+      if(dropTarget === element) return;
+      if(dropTarget){
+        dropTarget.classList.remove('drop-target');
+      }
+      dropTarget = element;
+      if(dropTarget){
+        dropTarget.classList.add('drop-target');
+      }
+    }
+
+    function finalizeMove(origin, target, stack){
+      if(!target || !stack.length) return false;
+      if(target.type === 'tableau'){
+        if(!isValidTableauMove(stack, target.index)) return false;
+        saveState();
+        const freshOrigin = getCardLocation(stack[0].id);
+        if(!freshOrigin){
+          state.history.pop();
+          updateUndo();
+          return false;
+        }
+        const moved = removeFromOrigin(freshOrigin, stack.length);
+        addToTarget(target, moved);
+        pendingFocusToken = { type: 'card', id: moved[0].id };
+        updateStatus(`Moved ${describeCard(moved[0])} to tableau pile ${target.index + 1}.`);
+        afterMutation();
+        return true;
+      }
+      if(target.type === 'foundation'){
+        if(stack.length !== 1) return false;
+        const card = stack[0];
+        if(!isValidFoundationMove(card, target.index)) return false;
+        saveState();
+        const freshOrigin = getCardLocation(card.id);
+        if(!freshOrigin){
+          state.history.pop();
+          updateUndo();
+          return false;
+        }
+        const moved = removeFromOrigin(freshOrigin, 1);
+        addToTarget(target, moved);
+        pendingFocusToken = { type: 'card', id: card.id };
+        updateStatus(`Placed ${describeCard(card)} on foundation ${target.index + 1}.`);
+        afterMutation();
+        return true;
+      }
+      return false;
+    }
+
+    function attemptAutoFoundation(cardId){
+      const loc = getCardLocation(cardId);
+      if(!loc || !loc.card.faceUp) return false;
+      if(loc.type === 'waste' && loc.position !== state.waste.length - 1) return false;
+      if(loc.type === 'foundation' && loc.position !== state.foundations[loc.index].length - 1) return false;
+      const card = loc.card;
+      for(let i = 0; i < state.foundations.length; i++){
+        if(isValidFoundationMove(card, i)){
+          saveState();
+          const fresh = getCardLocation(cardId);
+          if(!fresh){
+            state.history.pop();
+            updateUndo();
+            return false;
+          }
+          const moved = removeFromOrigin(fresh, 1);
+          addToTarget({ type: 'foundation', index: i }, moved);
+          pendingFocusToken = { type: 'card', id: card.id };
+          updateStatus(`Sent ${describeCard(card)} to foundation ${i + 1}.`);
+          afterMutation();
+          return true;
+        }
+      }
+      updateStatus(`No foundation available for ${describeCard(card)}.`);
+      return false;
+    }
+
+    function attemptAutoTableau(cardId){
+      const loc = getCardLocation(cardId);
+      if(!loc || !loc.card.faceUp) return false;
+      if(loc.type === 'waste' && loc.position !== state.waste.length - 1) return false;
+      if(loc.type === 'foundation' && loc.position !== state.foundations[loc.index].length - 1) return false;
+      const stack = loc.type === 'tableau' ? loc.pile.slice(loc.position) : [loc.card];
+      for(let i = 0; i < state.tableau.length; i++){
+        if(loc.type === 'tableau' && loc.index === i) continue;
+        if(isValidTableauMove(stack, i)){
+          saveState();
+          const fresh = getCardLocation(cardId);
+          if(!fresh){
+            state.history.pop();
+            updateUndo();
+            return false;
+          }
+          const count = fresh.type === 'tableau' ? fresh.pile.length - fresh.position : 1;
+          const moved = removeFromOrigin(fresh, count);
+          addToTarget({ type: 'tableau', index: i }, moved);
+          pendingFocusToken = { type: 'card', id: moved[0].id };
+          updateStatus(`Moved ${describeCard(moved[0])} to tableau pile ${i + 1}.`);
+          afterMutation();
+          return true;
+        }
+      }
+      updateStatus(`No tableau move available for ${describeCard(stack[0])}.`);
+      return false;
+    }
+
+    function clearDrag(targetEl){
+      if(!dragState) return;
+      dragState.elements.forEach(el => {
+        el.classList.remove('dragging');
+        el.style.pointerEvents = '';
+        el.style.transform = '';
+      });
+      if(targetEl){
+        targetEl.releasePointerCapture?.(dragState.pointerId);
+        targetEl.removeEventListener('pointermove', onCardPointerMove);
+        targetEl.removeEventListener('pointerup', onCardPointerUp);
+        targetEl.removeEventListener('pointercancel', onCardPointerCancel);
+      }
+      setDropTarget(null);
+    }
+
+    function onCardPointerDown(e){
+      const cardEl = e.target.closest('.card');
+      if(!cardEl) return;
+      if(e.pointerType === 'mouse' && e.button !== 0) return;
+      const cardId = cardEl.dataset.id;
+      if(!cardId) return;
+      const location = getCardLocation(cardId);
+      if(!location || !location.card.faceUp) return;
+      if(location.type === 'waste' && location.position !== state.waste.length - 1) return;
+      if(location.type === 'foundation' && location.position !== state.foundations[location.index].length - 1) return;
+      const stack = location.type === 'tableau' ? location.pile.slice(location.position) : [location.card];
+      const elements = stack.map(card => board.querySelector(`.card[data-id="${card.id}"]`)).filter(Boolean);
+      if(!elements.length) return;
+      dragState = {
+        origin: { type: location.type, index: location.index, position: location.position },
+        stack,
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        elements,
+        source: cardEl
+      };
+      elements.forEach(el => {
+        el.classList.add('dragging');
+        el.style.pointerEvents = 'none';
+      });
+      cardEl.setPointerCapture?.(e.pointerId);
+      cardEl.addEventListener('pointermove', onCardPointerMove);
+      cardEl.addEventListener('pointerup', onCardPointerUp);
+      cardEl.addEventListener('pointercancel', onCardPointerCancel);
+      e.preventDefault();
+    }
+
+    function onCardPointerMove(e){
+      if(!dragState || e.pointerId !== dragState.pointerId) return;
+      const dx = e.clientX - dragState.startX;
+      const dy = e.clientY - dragState.startY;
+      dragState.elements.forEach((el, index) => {
+        el.style.transform = `translate(${dx}px, ${dy}px)`;
+      });
+      const potential = document.elementFromPoint(e.clientX, e.clientY);
+      const pileEl = potential ? potential.closest('.pile') : null;
+      const descriptor = describeTargetFromElement(pileEl);
+      if(descriptor && isDropAllowed(descriptor, dragState)){
+        setDropTarget(pileEl);
+      } else {
+        setDropTarget(null);
+      }
+    }
+
+    function onCardPointerUp(e){
+      if(!dragState || e.pointerId !== dragState.pointerId) return;
+      const potential = document.elementFromPoint(e.clientX, e.clientY);
+      const pileEl = potential ? potential.closest('.pile') : null;
+      const descriptor = describeTargetFromElement(pileEl);
+      const origin = dragState.origin;
+      const stack = dragState.stack;
+      clearDrag(e.currentTarget);
+      const moved = descriptor && finalizeMove(origin, descriptor, stack);
+      if(!moved){
+        dragState.elements.forEach(el => { el.style.transform = ''; });
+        if(descriptor && !isSameDestination(descriptor, origin)){
+          updateStatus('That move is not allowed.');
+        }
+      }
+      dragState = null;
+    }
+
+    function onCardPointerCancel(e){
+      if(!dragState || e.pointerId !== dragState.pointerId) return;
+      clearDrag(e.currentTarget);
+      dragState = null;
+    }
+
+    function drawFromStock(){
+      if(state.stock.length){
+        saveState();
+        const card = state.stock.pop();
+        card.faceUp = true;
+        state.waste.push(card);
+        pendingFocusToken = { type: 'card', id: card.id };
+        updateStatus(`Drew ${describeCard(card)}.`);
+        afterMutation();
+        return true;
+      }
+      if(state.waste.length){
+        saveState();
+        while(state.waste.length){
+          const card = state.waste.pop();
+          card.faceUp = false;
+          state.stock.push(card);
+        }
+        pendingFocusToken = { type: 'pile', id: 'stock' };
+        updateStatus('Restacked the waste into the stock.');
+        afterMutation();
+        return true;
+      }
+      updateStatus('No cards available to draw.');
+      return false;
+    }
+
+    function undoMove(){
+      if(!state.history.length) return;
+      const snapshot = state.history.pop();
+      restoreSnapshot(snapshot);
+      updateStatus(snapshot.status || 'Undid the last move.');
+      pendingFocusToken = null;
+      render();
+      updateUndo();
+      checkWin();
+    }
+
+    function checkWin(){
+      const total = state.foundations.reduce((sum, pile) => sum + pile.length, 0);
+      if(total === 52){
+        updateStatus('You win! Press Restart to play again.');
+      }
+    }
+
+    function render(){
+      const focusPreference = pendingFocusToken || focusToken;
+      pendingFocusToken = null;
+
+      // Stock
+      stockEl.innerHTML = '';
+      stockEl.classList.toggle('has-cards', state.stock.length > 0);
+      stockEl.classList.toggle('is-empty', state.stock.length === 0);
+      if(state.stock.length){
+        const backCard = createCardElement(state.stock[state.stock.length - 1], { faceDown: true });
+        backCard.setAttribute('aria-hidden', 'true');
+        backCard.tabIndex = -1;
+        backCard.style.pointerEvents = 'none';
+        stockEl.appendChild(backCard);
+        stockEl.setAttribute('data-count', state.stock.length);
+        stockEl.setAttribute('aria-label', `Stock pile with ${pluralize(state.stock.length, 'card')}. Activate to draw.`);
+      } else {
+        stockEl.removeAttribute('data-count');
+        const recycleHint = state.waste.length ? 'Activate to recycle the waste pile.' : 'Stock pile is empty.';
+        stockEl.setAttribute('aria-label', recycleHint);
+      }
+
+      // Waste
+      wasteEl.innerHTML = '';
+      wasteEl.classList.toggle('has-cards', state.waste.length > 0);
+      const wasteVisible = state.waste.slice(-3);
+      wasteVisible.forEach((card, idx) => {
+        const position = state.waste.length - wasteVisible.length + idx;
+        const cardEl = createCardElement(card);
+        cardEl.dataset.pile = 'waste';
+        cardEl.dataset.position = String(position);
+        cardEl.style.left = `${idx * WASTE_SPACING}px`;
+        cardEl.style.zIndex = String(10 + idx);
+        const isTop = position === state.waste.length - 1;
+        cardEl.classList.toggle('is-top', isTop);
+        cardEl.tabIndex = isTop ? 0 : -1;
+        if(!isTop) cardEl.setAttribute('aria-hidden', 'true');
+        wasteEl.appendChild(cardEl);
+      });
+      if(state.waste.length){
+        const top = state.waste[state.waste.length - 1];
+        wasteEl.setAttribute('aria-label', `Waste pile. Top card ${describeCard(top)}.`);
+      } else {
+        wasteEl.setAttribute('aria-label', 'Waste pile is empty.');
+      }
+
+      // Foundations
+      foundationEls.forEach((pileEl, index) => {
+        pileEl.innerHTML = '';
+        const pile = state.foundations[index];
+        pileEl.classList.toggle('has-cards', pile.length > 0);
+        if(pile.length){
+          const top = pile[pile.length - 1];
+          const cardEl = createCardElement(top);
+          cardEl.dataset.pile = `foundation-${index}`;
+          cardEl.dataset.position = String(pile.length - 1);
+          cardEl.classList.add('is-top');
+          cardEl.tabIndex = 0;
+          pileEl.appendChild(cardEl);
+          pileEl.setAttribute('aria-label', `Foundation pile ${index + 1}. Top card ${describeCard(top)}.`);
+        } else {
+          pileEl.setAttribute('aria-label', `Foundation pile ${index + 1} is empty.`);
+        }
+      });
+
+      // Tableau
+      tableauEls.forEach((pileEl, index) => {
+        pileEl.innerHTML = '';
+        const pile = state.tableau[index];
+        pileEl.classList.toggle('has-cards', pile.length > 0);
+        let offset = 0;
+        pile.forEach((card, position) => {
+          const cardEl = createCardElement(card);
+          cardEl.dataset.pile = `tableau-${index}`;
+          cardEl.dataset.position = String(position);
+          cardEl.style.top = `${offset}px`;
+          cardEl.style.zIndex = String(position + 1);
+          cardEl.tabIndex = card.faceUp ? 0 : -1;
+          pileEl.appendChild(cardEl);
+          offset += card.faceUp ? FACE_UP_SPACING : FACE_DOWN_SPACING;
+        });
+        const height = Math.max(CARD_HEIGHT, offset + CARD_HEIGHT - FACE_UP_SPACING);
+        pileEl.style.minHeight = `${height}px`;
+        if(pile.length){
+          const top = pile[pile.length - 1];
+          const label = top.faceUp ? describeCard(top) : 'a face-down card';
+          pileEl.setAttribute('aria-label', `Tableau pile ${index + 1} with ${pluralize(pile.length, 'card')}. Top card ${label}.`);
+        } else {
+          pileEl.setAttribute('aria-label', `Tableau pile ${index + 1} is empty. Place a King here.`);
+        }
+      });
+
+      updateUndo();
+      restoreFocus(focusPreference);
+      checkWin();
+    }
+
+    function restoreFocus(token){
+      if(!token) return;
+      if(token.type === 'card'){
+        const el = board.querySelector(`.card[data-id="${token.id}"]`);
+        if(el){
+          el.focus({ preventScroll: true });
+          return;
+        }
+      }
+      if(token.type === 'pile'){
+        const el = board.querySelector(`.pile[data-pile="${token.id}"]`);
+        if(el){
+          el.focus({ preventScroll: true });
+        }
+      }
+    }
+
+    function afterMutation(){
+      render();
+    }
+
+    function setupNewGame(){
+      const deck = createDeck();
+      shuffle(deck);
+      state.tableau = Array.from({ length: 7 }, () => []);
+      for(let pile = 0; pile < 7; pile++){
+        for(let depth = 0; depth <= pile; depth++){
+          const card = deck.shift();
+          card.faceUp = depth === pile;
+          state.tableau[pile].push(card);
+        }
+      }
+      state.stock = deck;
+      state.stock.forEach(card => { card.faceUp = false; });
+      state.waste = [];
+      state.foundations = Array.from({ length: 4 }, () => []);
+      state.history = [];
+      updateUndo();
+      pendingFocusToken = { type: 'pile', id: 'stock' };
+      updateStatus('New game ready. Good luck!');
+      render();
+    }
+
+    board.addEventListener('pointerdown', onCardPointerDown);
+    restartBtn?.addEventListener('click', () => {
+      setupNewGame();
+      if(stockEl && typeof stockEl.focus === 'function'){
+        try {
+          stockEl.focus({ preventScroll: true });
+        } catch (err) {
+          stockEl.focus();
+        }
+      }
+    });
+    undoBtn?.addEventListener('click', () => undoMove());
+
+    stockEl.addEventListener('click', () => drawFromStock());
+    stockEl.addEventListener('keydown', (e) => {
+      if(e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar'){
+        e.preventDefault();
+        drawFromStock();
+      }
+    });
+
+    wasteEl.addEventListener('keydown', (e) => {
+      if(e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar'){
+        e.preventDefault();
+        const top = state.waste[state.waste.length - 1];
+        if(!top) return;
+        if(e.shiftKey){
+          attemptAutoTableau(top.id);
+        } else {
+          if(!attemptAutoFoundation(top.id)){
+            attemptAutoTableau(top.id);
+          }
+        }
+      }
+    });
+
+    foundationEls.forEach((pileEl, index) => {
+      pileEl.addEventListener('keydown', (e) => {
+        if(e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar'){
+          e.preventDefault();
+          const pile = state.foundations[index];
+          const top = pile[pile.length - 1];
+          if(!top) return;
+          attemptAutoTableau(top.id);
+        }
+      });
+    });
+
+    board.addEventListener('dblclick', (e) => {
+      const cardEl = e.target.closest('.card');
+      if(!cardEl) return;
+      const cardId = cardEl.dataset.id;
+      if(!cardId) return;
+      if(!attemptAutoFoundation(cardId)){
+        attemptAutoTableau(cardId);
+      }
+    });
+
+    board.addEventListener('keydown', (e) => {
+      const cardEl = e.target.closest('.card');
+      if(!cardEl) return;
+      const cardId = cardEl.dataset.id;
+      if(!cardId) return;
+      if(e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar'){
+        e.preventDefault();
+        if(e.shiftKey){
+          attemptAutoTableau(cardId);
+        } else {
+          if(!attemptAutoFoundation(cardId)){
+            attemptAutoTableau(cardId);
+          }
+        }
+      } else if(e.key.toLowerCase() === 'f'){
+        e.preventDefault();
+        attemptAutoFoundation(cardId);
+      } else if(e.key.toLowerCase() === 't'){
+        e.preventDefault();
+        attemptAutoTableau(cardId);
+      }
+    });
+
+    board.addEventListener('focusin', (e) => {
+      const cardEl = e.target.closest('.card');
+      if(cardEl){
+        focusToken = { type: 'card', id: cardEl.dataset.id };
+        return;
+      }
+      const pileEl = e.target.closest('.pile');
+      if(pileEl){
+        focusToken = { type: 'pile', id: pileEl.getAttribute('data-pile') };
+      }
+    });
+
+    win.addEventListener('keydown', (e) => {
+      if((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z'){
+        e.preventDefault();
+        undoMove();
+      }
+    });
+
+    setupNewGame();
+
+    function createCardElement(card, { faceDown } = {}){
+      const isFaceDown = faceDown ?? !card.faceUp;
+      const el = document.createElement('div');
+      el.className = 'card';
+      el.dataset.id = card.id;
+      el.dataset.rank = card.rank;
+      el.dataset.suit = card.suit;
+      el.dataset.value = String(card.value);
+      if(!isFaceDown){
+        el.classList.add('face-up');
+        if(card.color === 'red') el.classList.add('red');
+      } else {
+        el.classList.add('face-down', 'back');
+      }
+      const rankSpan = document.createElement('span');
+      rankSpan.className = 'rank';
+      rankSpan.textContent = card.rank;
+      const suitSpan = document.createElement('span');
+      suitSpan.className = 'suit';
+      suitSpan.textContent = SUIT_SYMBOLS[card.suit];
+      el.append(rankSpan, suitSpan);
+      el.setAttribute('role', 'button');
+      if(isFaceDown){
+        el.setAttribute('aria-label', 'Face-down card');
+      } else {
+        el.setAttribute('aria-label', describeCard(card));
+      }
+      return el;
+    }
+  }
+
+  window.initSolitaireWindow = initSolitaireWindow;
+})();

--- a/styles.css
+++ b/styles.css
@@ -87,15 +87,66 @@ body{margin:0; font:14px/1 "Jersey 20", sans-serif; color:var(--text); backgroun
 .start-menu .hr{height:1px; background:#ccc; margin:4px 0}
 
 /* Sticky notes */
-.sticky-note{position:absolute; background:#fffbe8; color:#222; border:1px solid #e7da93; box-shadow:3px 3px 0 #000; padding:10px 28px 10px 10px; border-radius:6px; width:220px; min-width:160px; min-height:120px; resize:both; overflow:auto; user-select:text}
-.sticky-note .body{min-height:80px; outline:none; user-select:text; white-space:pre-wrap;}
-.sticky-note .body:empty:before{content:'New note…'; color:#555;}
-.sticky-note .close{position:absolute; right:6px; top:6px; width:18px; height:18px; background:#000; color:#fffbe8; border:1px solid #000; border-radius:2px; cursor:pointer}
-.sticky-note.dragging{opacity:.9}
-.sticky-toolbar{display:flex; gap:8px; margin-bottom:8px}
-.sticky-btn{padding:6px 10px; border:2px solid #ccc; background:#eee; color:#000; border-radius:2px; cursor:pointer}
-.sticky-list{font-size:10px; color:#555}
-.sticky-list code{color:#000}
+
+/* Solitaire window */
+.solitaire{display:flex; flex-direction:column; gap:12px; min-width:640px; max-width:100%; color:#0b2542; background:linear-gradient(135deg,#f5f7fa,#dce7ff 48%,#f5f7fa); padding:12px; box-sizing:border-box; border:1px solid #7e9bd1; border-radius:6px;}
+.solitaire h2{font-size:20px; margin:0 0 4px; color:#13294b;}
+.solitaire-toolbar{display:flex; flex-wrap:wrap; gap:12px; justify-content:space-between; align-items:flex-start;}
+.solitaire-heading{flex:1 1 260px;}
+.solitaire-instructions{margin:0; font-size:13px; color:#314a72;}
+.solitaire-actions{display:flex; gap:8px; align-items:center;}
+.solitaire-btn{padding:6px 12px; border:2px solid #243b63; background:#fff; color:#13294b; border-radius:4px; font-weight:700; cursor:pointer; box-shadow:2px 2px 0 rgba(12,27,51,.2);}
+.solitaire-btn:disabled{opacity:.6; cursor:not-allowed; box-shadow:none;}
+.solitaire-btn:focus-visible{outline:2px solid #ffb400; outline-offset:2px;}
+.solitaire-status{min-height:20px; font-size:13px; color:#102240; padding:4px 0;}
+.solitaire-board{display:flex; flex-direction:column; gap:16px; background:rgba(10,46,82,.08); border:1px solid rgba(19,41,75,.2); border-radius:8px; padding:16px; overflow:auto; box-shadow:inset 0 0 0 1px rgba(255,255,255,.3);}
+.solitaire-row{display:flex; gap:16px; flex-wrap:wrap; align-items:flex-start;}
+.solitaire-row--top{justify-content:space-between;}
+.solitaire-foundations{display:flex; gap:16px; flex-wrap:wrap;}
+.pile{position:relative; width:96px; min-height:128px; border-radius:8px; border:2px dashed rgba(19,41,75,.35); background:rgba(255,255,255,.55); box-shadow:inset 0 2px 6px rgba(0,0,0,.08); transition:border-color .2s, background .2s, box-shadow .2s; outline:none;}
+.pile[data-pile^="tableau"]{min-height:360px; width:112px;}
+.pile:focus-visible{border-color:#ffb400; box-shadow:0 0 0 3px rgba(255,180,0,.35);}
+.pile.drop-target{border-style:solid; border-color:#39a275; background:rgba(57,162,117,.15); box-shadow:0 0 0 3px rgba(57,162,117,.25);}
+.pile::after{content:''; position:absolute; inset:4px; border-radius:6px; border:1px dashed rgba(19,41,75,.2); pointer-events:none;}
+.pile.has-cards::after{display:none;}
+.pile-label{position:absolute; left:8px; top:6px; font-size:12px; color:#567;}
+.card{position:absolute; width:84px; height:120px; border-radius:8px; border:2px solid #0f2242; background:#fff; color:#102240; display:flex; flex-direction:column; justify-content:space-between; padding:6px 8px; box-sizing:border-box; box-shadow:2px 2px 0 rgba(15,34,66,.25); cursor:grab; touch-action:none; transition:transform .15s ease, box-shadow .15s ease, filter .15s ease;}
+.card .rank{font-size:20px; font-weight:700;}
+.card .suit{font-size:18px; align-self:flex-end;}
+.card.red{color:#ba1b1d; border-color:#7f1213;}
+.card.back{background:repeating-linear-gradient(135deg,#234567,#234567 6px,#1b3a63 6px,#1b3a63 12px); border-color:#0b1c36; color:transparent; box-shadow:2px 2px 0 rgba(0,0,0,.3);}
+.card.back .rank,.card.back .suit{visibility:hidden;}
+.card.face-down{cursor:default;}
+.card.dragging{cursor:grabbing; box-shadow:6px 8px 12px rgba(0,0,0,.25); filter:brightness(1.05);}
+.card:focus-visible{outline:2px solid #ffb400; outline-offset:2px;}
+.card.is-valid-target{box-shadow:0 0 0 3px rgba(57,162,117,.45);}
+.card.is-top{z-index:10;}
+.pile[data-pile^="tableau"] .card{width:92px;}
+.pile[data-pile^="tableau"] .card.face-up{cursor:grab;}
+.pile[data-pile^="tableau"] .card.face-down{cursor:default;}
+.pile[data-pile="waste"]{width:96px; min-height:128px;}
+.pile[data-pile="stock"]::before{content:attr(data-count); position:absolute; bottom:6px; right:8px; font-size:12px; color:rgba(255,255,255,.85); font-weight:700; text-shadow:0 1px 2px rgba(0,0,0,.6);}
+.pile[data-pile="stock"].is-empty{background:rgba(255,255,255,.35); border-style:dotted; color:#243b63;}
+.pile[data-pile="stock"].is-empty::before{content:'↺'; color:#243b63; font-size:20px;}
+.solitaire-board::-webkit-scrollbar{height:10px;}
+.solitaire-board::-webkit-scrollbar-thumb{background:#9ab5e0; border-radius:5px;}
+.solitaire-board::-webkit-scrollbar-track{background:rgba(19,41,75,.12);}
+.solitaire{font-family:'Monaco',monospace;}
+.solitaire-row--tableau{justify-content:space-between;}
+.solitaire-row--tableau .pile{flex:1 1 110px;}
+.solitaire-row--tableau .pile:not(:last-child){margin-right:0;}
+.pile[data-pile^="tableau"] .card{top:calc(var(--card-top, 0px));}
+.pile[data-pile="waste"] .card{top:0;}
+.pile[data-pile^="foundation"] .card{top:0;}
+.card.is-hidden{opacity:0;}
+.solitaire .sr-only{position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0;}
+@media (max-width:880px){
+  .solitaire{min-width:0;}
+  .solitaire-row{justify-content:center;}
+  .solitaire-row--top{justify-content:center;}
+  .solitaire-foundations{justify-content:center;}
+  .solitaire-row--tableau{justify-content:center;}
+}
 
 /* About window */
 .content-section.about .about-hero{display:flex; flex-direction:column; align-items:center; gap:16px; margin:0 0 16px}


### PR DESCRIPTION
## Summary
- replace the sticky note launcher with a Solitaire entry on the desktop and in the start menu, and scaffold the new window template
- add dedicated styling for the Solitaire layout, cards, and responsive behavior
- implement the Solitaire game logic with drag-and-drop, keyboard controls, undo/restart, and wire it into the window system

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e08c2fdf148322ad85f001527a2d81