### PR TITLE
Add Solitaire game window to desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,9 +32,9 @@
   <img src="assets/img/Contact1.png" alt="" />
   <div class="label">Contact</div>
 </div>
-<div class="icon sticky" tabindex="0" role="button" aria-label="Sticky Notes">
+<div class="icon solitaire" tabindex="0" role="button" aria-label="Solitaire">
   <img src="assets/img/solitaire.png" alt="" />
-  <div class="label">Sticky Notes </div> 
+  <div class="label">Solitaire</div>
 </div>
 <div class="icon publishers" tabindex="0" role="button" aria-label="Publishers">
   <img src="assets/img/vinyl.png" alt="" />
@@ -69,6 +69,9 @@
   </div>
   <div class="item" role="menuitem" data-open="publishers">
     <span>Publishers</span>
+  </div>
+  <div class="item" role="menuitem" data-open="solitaire">
+    <span>Solitaire</span>
   </div>
   <div class="hr" role="separator"></div>
   <div class="item" role="menuitem" data-cmd="closeAll">
@@ -540,7 +543,32 @@
   </section>
 </template>
 
+<template id="tpl-solitaire">
+  <section class="solitaire-board" data-role="solitaire">
+    <div class="solitaire-top-row">
+      <div class="pile stock" data-role="stock" data-pile-type="stock" data-index="0" aria-label="Stock" tabindex="0"></div>
+      <div class="pile waste" data-role="waste" data-pile-type="waste" data-index="0" aria-label="Waste" tabindex="0"></div>
+      <div class="foundation-group" data-role="foundations">
+        <div class="pile foundation" data-role="foundation" data-pile-type="foundation" data-index="0" aria-label="Foundation 1" tabindex="0"></div>
+        <div class="pile foundation" data-role="foundation" data-pile-type="foundation" data-index="1" aria-label="Foundation 2" tabindex="0"></div>
+        <div class="pile foundation" data-role="foundation" data-pile-type="foundation" data-index="2" aria-label="Foundation 3" tabindex="0"></div>
+        <div class="pile foundation" data-role="foundation" data-pile-type="foundation" data-index="3" aria-label="Foundation 4" tabindex="0"></div>
+      </div>
+    </div>
+    <div class="solitaire-tableau" data-role="tableau">
+      <div class="pile tableau" data-role="tableau" data-pile-type="tableau" data-index="0" aria-label="Tableau Pile 1" tabindex="0"></div>
+      <div class="pile tableau" data-role="tableau" data-pile-type="tableau" data-index="1" aria-label="Tableau Pile 2" tabindex="0"></div>
+      <div class="pile tableau" data-role="tableau" data-pile-type="tableau" data-index="2" aria-label="Tableau Pile 3" tabindex="0"></div>
+      <div class="pile tableau" data-role="tableau" data-pile-type="tableau" data-index="3" aria-label="Tableau Pile 4" tabindex="0"></div>
+      <div class="pile tableau" data-role="tableau" data-pile-type="tableau" data-index="4" aria-label="Tableau Pile 5" tabindex="0"></div>
+      <div class="pile tableau" data-role="tableau" data-pile-type="tableau" data-index="5" aria-label="Tableau Pile 6" tabindex="0"></div>
+      <div class="pile tableau" data-role="tableau" data-pile-type="tableau" data-index="6" aria-label="Tableau Pile 7" tabindex="0"></div>
+    </div>
+  </section>
+</template>
+
 
 <script src="script.js" defer></script>
+<script src="solitaire.js" defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -442,6 +442,13 @@ const openers = {
     const win = makeWindow({ title: 'Publishers', tpl: 'tpl-publishers', x: 220, y: 200, w: 440 });
     if (typeof initPublishersWindow === 'function') initPublishersWindow(win);
     return win;
+  },
+
+  solitaire: () => {
+    const win = makeWindow({ title: 'Solitaire', tpl: 'tpl-solitaire', x: 180, y: 120, w: 880 });
+    win.classList.add('solitaire');
+    if (typeof initSolitaireWindow === 'function') initSolitaireWindow(win);
+    return win;
   }
 };
 // Icon drag + dblclick handlers

--- a/styles.css
+++ b/styles.css
@@ -166,3 +166,176 @@ body{margin:0; font:14px/1 "Jersey 20", sans-serif; color:var(--text); backgroun
   .placements-figure{flex:0 0 260px; max-width:320px}
   .placements-copy{flex:1}
 }
+
+/* Solitaire window */
+.window.solitaire .content{
+  padding:0;
+  background:radial-gradient(circle at top left, #3fa55b, #0b4a1d 70%);
+  color:#fff;
+}
+
+.window.solitaire .solitaire-board{
+  --card-width:88px;
+  --card-height:124px;
+  --tableau-faceup-offset:32px;
+  --tableau-facedown-offset:18px;
+  --solitaire-gap:clamp(10px, 2vw, 20px);
+  display:flex;
+  flex-direction:column;
+  gap:var(--solitaire-gap);
+  padding:18px;
+  min-height:100%;
+  box-sizing:border-box;
+  user-select:none;
+  position:relative;
+}
+
+.window.solitaire .solitaire-top-row{
+  display:flex;
+  align-items:flex-start;
+  gap:var(--solitaire-gap);
+}
+
+.window.solitaire .foundation-group{
+  display:flex;
+  gap:var(--solitaire-gap);
+  margin-left:auto;
+}
+
+.window.solitaire .solitaire-tableau{
+  display:grid;
+  grid-template-columns:repeat(7, var(--card-width));
+  gap:var(--solitaire-gap);
+  justify-content:flex-start;
+}
+
+.window.solitaire .pile{
+  position:relative;
+  width:var(--card-width);
+  min-height:var(--card-height);
+  border-radius:10px;
+  border:2px dashed rgba(255,255,255,0.4);
+  background:rgba(255,255,255,0.08);
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,0.25);
+  transition:border-color 0.2s ease;
+}
+
+.window.solitaire .pile::before{
+  content:'';
+  position:absolute;
+  inset:6px;
+  border-radius:8px;
+  border:1px dashed rgba(255,255,255,0.2);
+  pointer-events:none;
+}
+
+.window.solitaire .pile.is-empty{
+  border-color:rgba(255,255,255,0.65);
+}
+
+.window.solitaire .pile[data-pile-type="tableau"]{
+  min-height:calc(var(--computed-height, var(--card-height)));
+}
+
+.window.solitaire .pile[data-pile-type="stock"],
+.window.solitaire .pile[data-pile-type="waste"],
+.window.solitaire .pile[data-pile-type="foundation"]{
+  min-height:var(--card-height);
+}
+
+.window.solitaire .solitaire-card{
+  position:absolute;
+  top:0;
+  left:0;
+  width:var(--card-width);
+  height:var(--card-height);
+  border-radius:12px;
+  border:2px solid rgba(255,255,255,0.9);
+  background:rgba(255,255,255,0.85);
+  background-image:url('assets/img/logo.png');
+  background-size:cover;
+  background-position:center;
+  box-shadow:0 6px 12px rgba(0,0,0,0.35);
+  display:flex;
+  align-items:flex-start;
+  justify-content:flex-start;
+  padding:6px;
+  box-sizing:border-box;
+  transition:transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.window.solitaire .solitaire-card.is-face-down{
+  filter:saturate(0.3) brightness(0.75);
+}
+
+.window.solitaire .solitaire-card.is-face-up{
+  filter:none;
+}
+
+.window.solitaire .solitaire-card.is-hidden{
+  display:none;
+}
+
+.window.solitaire .solitaire-card .card-label{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:28px;
+  padding:2px 6px;
+  border-radius:6px;
+  background:rgba(255,255,255,0.85);
+  color:#111;
+  font-weight:700;
+  font-size:clamp(0.7rem, 1.4vw, 1rem);
+  box-shadow:0 1px 3px rgba(0,0,0,0.35);
+}
+
+.window.solitaire .solitaire-card.is-face-down .card-label{
+  opacity:0;
+}
+
+.window.solitaire .solitaire-card:focus-visible{
+  outline:3px solid #ffe066;
+  outline-offset:2px;
+}
+
+.window.solitaire .solitaire-drag-ghost{
+  position:fixed;
+  pointer-events:none;
+  z-index:10000;
+}
+
+.window.solitaire .solitaire-drag-ghost .ghost-card{
+  position:absolute;
+  pointer-events:none;
+  filter:drop-shadow(0 8px 10px rgba(0,0,0,0.45));
+}
+
+.window.solitaire .solitaire-board.is-complete::after{
+  content:'You win!';
+  position:absolute;
+  inset:auto 18px 18px auto;
+  background:rgba(255,255,255,0.85);
+  color:#064420;
+  padding:10px 18px;
+  border-radius:12px;
+  font-weight:700;
+  font-size:1rem;
+  box-shadow:0 10px 20px rgba(0,0,0,0.35);
+}
+
+.window.solitaire .pile[data-pile-type="waste"] .solitaire-card{
+  transition:none;
+}
+
+@media (max-width:900px){
+  .window.solitaire .solitaire-board{
+    padding:14px;
+  }
+  .window.solitaire .solitaire-tableau{
+    gap:clamp(8px, 1.5vw, 14px);
+  }
+  .window.solitaire .foundation-group{
+    gap:clamp(8px, 1.5vw, 14px);
+  }
+}


### PR DESCRIPTION
## Summary
- add a Solitaire desktop icon, start menu entry, and window template for the game
- implement a Klondike solitaire engine with responsive sizing and drag/double-click interaction hooks
- style the Solitaire window to organize stock, foundation, waste, and tableau piles with branded card artwork

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0959b353c8322bc3379518ce63584